### PR TITLE
psysh-doc-buffer-color: fix odd type warning in native compilation

### DIFF
--- a/psysh.el
+++ b/psysh.el
@@ -230,11 +230,11 @@ See `psysh-mode-output-syntax-table'."
 
 (defcustom psysh-doc-buffer-color 'auto
   "Coloring PsySH buffer."
-  :type '(choice (const :tag "Auto detect color mode." 'auto)
-                 (const :tag "Use only PsySH original coloring." 'only-psysh)
-                 (const :tag "Use only Emacs font-lock coloring." 'only-emacs)
-                 (const :tag "Use multiple coloring mechanism." 'mixed)
-                 (const :tag "No coloring." 'none)))
+  :type '(choice (const :tag "Auto detect color mode." auto)
+                 (const :tag "Use only PsySH original coloring." only-psysh)
+                 (const :tag "Use only Emacs font-lock coloring." only-emacs)
+                 (const :tag "Use multiple coloring mechanism." mixed)
+                 (const :tag "No coloring." none)))
 
 (defcustom psysh-doc-display-function #'view-buffer-other-window
   "Function to display PsySH doc buffer."


### PR DESCRIPTION
Fixes:
```
psysh.el:231:12: Warning: defcustom for ‘psysh-doc-buffer-color’ has
    syntactically odd type ‘'(choice (const :tag Auto detect color
    mode. 'auto) (const :tag Use only PsySH original coloring. 'only-psysh)
    (const :tag Use only Emacs font-lock coloring. 'only-emacs) (const :tag
    Use multiple coloring mechanism. 'mixed) (const :tag No coloring. 'none))’
```